### PR TITLE
Add chemfiles benchmarks

### DIFF
--- a/chemfiles/.gitignore
+++ b/chemfiles/.gitignore
@@ -1,0 +1,6 @@
+count
+distance
+ramachandran
+parse_mmcif
+parse_mmtf
+parse_pdb

--- a/chemfiles/Makefile
+++ b/chemfiles/Makefile
@@ -1,0 +1,13 @@
+CPPFLAGS=-std=c++11 -O2
+INCLUDE=-I${CONDA_PREFIX}/include
+LIBS=-L${CONDA_PREFIX}/lib -lchemfiles -Wl,-rpath,${CONDA_PREFIX}/lib
+TARGETS=count distance parse_mmcif parse_mmtf parse_pdb ramachandran
+
+all: ${TARGETS}
+
+%: %.cpp
+	${CXX} ${CPPFLAGS} ${INCLUDE} $< -o $@ ${LIBS}
+
+.PHONY: clean
+clean:
+	rm -rf ${TARGETS}

--- a/chemfiles/README.md
+++ b/chemfiles/README.md
@@ -1,0 +1,6 @@
+Compile with:
+
+```
+conda install chemfiles-lib
+make
+```

--- a/chemfiles/count.cpp
+++ b/chemfiles/count.cpp
@@ -1,0 +1,27 @@
+// Benchmark the counting of alanine residues in a PDB file
+#include <cstdio>
+#include <string>
+
+#include <time.h>
+
+#include <chemfiles.hpp>
+
+using namespace chemfiles;
+
+static size_t count(Frame& frame) {
+    auto selection = Selection("resname ALA");
+    return selection.list(frame).size();
+}
+
+int main() {
+    auto pdb_filepath = "data/1AKE.pdb";
+    auto frame = Trajectory(pdb_filepath).read();
+
+    timespec tstart, tend;
+    clock_gettime(CLOCK_REALTIME, &tstart);
+    count(frame);
+    clock_gettime(CLOCK_REALTIME, &tend);
+
+    printf("%.6f\n", (tend.tv_sec - tstart.tv_sec) + (tend.tv_nsec - tstart.tv_nsec) / 1e9);
+    return 0;
+}

--- a/chemfiles/count.py
+++ b/chemfiles/count.py
@@ -1,0 +1,19 @@
+# Benchmark the counting of alanine residues in a PDB file
+
+import time
+from chemfiles import Trajectory, Selection
+
+
+def count(frame):
+    selection = Selection("resname ALA")
+    return len(selection.evaluate(frame))
+
+
+pdb_filepath = "data/1AKE.pdb"
+frame = Trajectory(pdb_filepath).read()
+
+start = time.time()
+count(frame)
+end = time.time()
+
+print(end - start)

--- a/chemfiles/distance.cpp
+++ b/chemfiles/distance.cpp
@@ -1,0 +1,44 @@
+// Benchmark the calculation of a distance in a PDB file
+// The distance is the closest distance between any atoms of residues 50 and 60
+//   of chain A in 1AKE
+#include <cstdio>
+#include <cmath>
+#include <string>
+
+#include <time.h>
+
+#include <chemfiles.hpp>
+
+using namespace chemfiles;
+
+static double distance(Frame& frame) {
+    // FIXME: this should use Selection("resid 50 and [chainname] A") which will
+    // be available in chemfiles 0.10 (the next release)
+    auto r50 = Selection("resid 50 and index < 1000").list(frame);
+    auto r60 = Selection("resid 60 and index < 1000").list(frame);
+
+    double min = INFINITY;
+    for (auto i: r50) {
+        for (auto j: r60) {
+            auto r = frame.distance(i, j);
+            if (r < min) {
+                min = r;
+            }
+        }
+    }
+
+    return min;
+}
+
+int main() {
+    auto pdb_filepath = "data/1AKE.pdb";
+    auto frame = Trajectory(pdb_filepath).read();
+
+    timespec tstart, tend;
+    clock_gettime(CLOCK_REALTIME, &tstart);
+    distance(frame);
+    clock_gettime(CLOCK_REALTIME, &tend);
+
+    printf("%.6f\n", (tend.tv_sec - tstart.tv_sec) + (tend.tv_nsec - tstart.tv_nsec) / 1e9);
+    return 0;
+}

--- a/chemfiles/distance.py
+++ b/chemfiles/distance.py
@@ -1,0 +1,32 @@
+# Benchmark the calculation of a distance in a PDB file
+# The distance is the closest distance between any atoms of residues 50 and 60
+#   of chain A in 1AKE
+
+import time
+from chemfiles import Trajectory, Selection
+
+
+def distance(frame):
+    # FIXME: this should use Selection("resid 50 and [chainname] A") which will
+    # be available in chemfiles 0.10 (the next release)
+    r50 = Selection("resid 50 and index < 1000").evaluate(frame)
+    r60 = Selection("resid 60 and index < 1000").evaluate(frame)
+
+    min = float('inf')
+    for i in r50:
+        for j in r60:
+            r = frame.distance(i, j)
+            if r < min:
+                min = r
+
+    return min
+
+
+pdb_filepath = "data/1AKE.pdb"
+frame = Trajectory(pdb_filepath).read()
+
+start = time.time()
+distance(frame)
+end = time.time()
+
+print(end - start)

--- a/chemfiles/parse_mmcif.cpp
+++ b/chemfiles/parse_mmcif.cpp
@@ -1,0 +1,18 @@
+// Benchmark the parsing of a mmCIF file given as an argument
+#include <cstdio>
+#include <string>
+#include <time.h>
+
+#include <chemfiles.hpp>
+
+int main(int argc, char* argv[]) {
+    std::string mmcif_filepath = argv[1];
+
+    struct timespec tstart, tend;
+    clock_gettime(CLOCK_REALTIME, &tstart);
+    auto frame = chemfiles::Trajectory(mmcif_filepath, 'r', "mmCIF").read();
+    clock_gettime(CLOCK_REALTIME, &tend);
+
+    printf("%.6f\n", (tend.tv_sec - tstart.tv_sec) + (tend.tv_nsec - tstart.tv_nsec) / 1e9);
+    return 0;
+}

--- a/chemfiles/parse_mmcif.py
+++ b/chemfiles/parse_mmcif.py
@@ -1,0 +1,13 @@
+# Benchmark the parsing of a mmCIF file given as an argument
+
+import sys
+import time
+from chemfiles import Trajectory
+
+mmcif_filepath = sys.argv[1]
+
+start = time.time()
+Trajectory(mmcif_filepath, 'r', 'mmCIF').read()
+end = time.time()
+
+print(end - start)

--- a/chemfiles/parse_mmtf.cpp
+++ b/chemfiles/parse_mmtf.cpp
@@ -1,0 +1,18 @@
+// Benchmark the parsing of a MMTF file given as an argument
+#include <cstdio>
+#include <string>
+#include <time.h>
+
+#include <chemfiles.hpp>
+
+int main(int argc, char* argv[]) {
+    std::string mmtf_filepath = argv[1];
+
+    struct timespec tstart, tend;
+    clock_gettime(CLOCK_REALTIME, &tstart);
+    auto frame = chemfiles::Trajectory(mmtf_filepath).read();
+    clock_gettime(CLOCK_REALTIME, &tend);
+
+    printf("%.6f\n", (tend.tv_sec - tstart.tv_sec) + (tend.tv_nsec - tstart.tv_nsec) / 1e9);
+    return 0;
+}

--- a/chemfiles/parse_mmtf.py
+++ b/chemfiles/parse_mmtf.py
@@ -1,0 +1,13 @@
+# Benchmark the parsing of a MMTF file given as an argument
+
+import sys
+import time
+from chemfiles import Trajectory
+
+mmtf_filepath = sys.argv[1]
+
+start = time.time()
+Trajectory(mmtf_filepath).read()
+end = time.time()
+
+print(end - start)

--- a/chemfiles/parse_pdb.cpp
+++ b/chemfiles/parse_pdb.cpp
@@ -1,0 +1,18 @@
+// Benchmark the parsing of a PDB file given as an argument
+#include <cstdio>
+#include <string>
+#include <time.h>
+
+#include <chemfiles.hpp>
+
+int main(int argc, char* argv[]) {
+    std::string mmtf_filepath = argv[1];
+
+    struct timespec tstart, tend;
+    clock_gettime(CLOCK_REALTIME, &tstart);
+    auto frame = chemfiles::Trajectory(mmtf_filepath).read();
+    clock_gettime(CLOCK_REALTIME, &tend);
+
+    printf("%.6f\n", (tend.tv_sec - tstart.tv_sec) + (tend.tv_nsec - tstart.tv_nsec) / 1e9);
+    return 0;
+}

--- a/chemfiles/parse_pdb.py
+++ b/chemfiles/parse_pdb.py
@@ -1,0 +1,13 @@
+# Benchmark the parsing of a PDB file given as an argument
+
+import sys
+import time
+from chemfiles import Trajectory
+
+pdb_filepath = sys.argv[1]
+
+start = time.time()
+Trajectory(pdb_filepath).read()
+end = time.time()
+
+print(end - start)

--- a/chemfiles/ramachandran.cpp
+++ b/chemfiles/ramachandran.cpp
@@ -1,0 +1,53 @@
+// Benchmark the calculation of Ramachandran phi/psi angles from a PDB file
+#include <cstdio>
+#include <cmath>
+#include <vector>
+#include <string>
+
+#include <time.h>
+
+#include <chemfiles.hpp>
+
+using namespace chemfiles;
+
+using ramachandran_t = std::pair<std::vector<double>, std::vector<double>>;
+static ramachandran_t ramachandran(Frame& frame) {
+    auto phi_selection = Selection("dihedrals: name(#1) C and name(#2) N and name(#3) CA and name(#4) C");
+    auto phi_list = phi_selection.evaluate(frame);
+
+    auto phi_angles = std::vector<double>();
+    phi_angles.reserve(phi_list.size());
+
+    for (const auto& phi: phi_list) {
+        // 57.29578 to convert from radians to degrees
+        phi_angles.push_back(frame.dihedral(phi[0], phi[1], phi[2], phi[3]) * 57.29578);
+    }
+
+
+    auto psi_selection = Selection("dihedrals: name(#1) N and name(#2) CA and name(#3) C and name(#4) N");
+    auto psi_list = psi_selection.evaluate(frame);
+
+    auto psi_angles = std::vector<double>();
+    psi_angles.reserve(psi_list.size());
+
+    for (const auto& phi: psi_list) {
+        // 57.29578 to convert from radians to degrees
+        phi_angles.push_back(frame.dihedral(phi[0], phi[1], phi[2], phi[3]) * 57.29578);
+    }
+
+    // FIXME: the sign of the angles is inverted w.r.t. the MDAnalysis results
+    return {phi_angles, psi_angles};
+}
+
+int main() {
+    auto pdb_filepath = "data/1AKE.pdb";
+    auto frame = Trajectory(pdb_filepath).read();
+
+    timespec tstart, tend;
+    clock_gettime(CLOCK_REALTIME, &tstart);
+    ramachandran(frame);
+    clock_gettime(CLOCK_REALTIME, &tend);
+
+    printf("%.6f\n", (tend.tv_sec - tstart.tv_sec) + (tend.tv_nsec - tstart.tv_nsec) / 1e9);
+    return 0;
+}

--- a/chemfiles/ramachandran.py
+++ b/chemfiles/ramachandran.py
@@ -1,0 +1,29 @@
+# Benchmark the calculation of Ramachandran phi/psi angles from a PDB file
+import time
+from chemfiles import Trajectory, Selection
+
+
+def ramachandran(frame):
+    phi_selection = Selection("dihedrals: name(#1) C and name(#2) N and name(#3) CA and name(#4) C")
+    phi_angles = []
+    for (i, j, k, m) in phi_selection.evaluate(frame):
+        # 57.29578 to convert from radians to degrees
+        phi_angles.append(frame.dihedral(i, j, k, m) * 57.29578)
+
+    psi_selection = Selection("dihedrals: name(#1) N and name(#2) CA and name(#3) C and name(#4) N")
+    psi_angles = []
+    for (i, j, k, m) in psi_selection.evaluate(frame):
+        psi_angles.append(frame.dihedral(i, j, k, m) * 57.29578)
+
+    # FIXME: the sign of the angles is inverted w.r.t. the MDAnalysis results
+    return phi_angles, psi_angles
+
+
+pdb_filepath = "data/1AKE.pdb"
+frame = Trajectory(pdb_filepath).read()
+
+start = time.time()
+ramachandran(frame)
+end = time.time()
+
+print(end - start)

--- a/tools/run_benchmarks.sh
+++ b/tools/run_benchmarks.sh
@@ -146,6 +146,31 @@ echo "Victor benchmarks done"
 run_benchmark $nb "ESBTL/parse_pdb data/1CRN.pdb" "ESBTL/parse_pdb_1CRN.dat" "ESBTL,Parse PDB 1CRN,"
 echo "ESBTL benchmarks done"
 
+# chemfiles -- Python
+run_benchmark $nb "python chemfiles/parse_pdb.py data/1CRN.pdb"   "chemfiles/parse_pdb_1CRN-python.dat"   "chemfiles-python,Parse PDB 1CRN,"
+# FIXME: this uncovered a bug in chemfiles, the bugfix will be avaible on
+# chemfiles>=0.10 when released
+#run_benchmark $ns "python chemfiles/parse_pdb.py data/1HTQ.pdb"   "chemfiles/parse_pdb_1HTQ_py.dat"   "chemfiles-python,Parse PDB 1HTQ,"
+run_benchmark $nb "python chemfiles/parse_mmcif.py data/1CRN.cif" "chemfiles/parse_mmcif_1CRN_py.dat" "chemfiles-python,Parse mmCIF 1CRN,"
+run_benchmark $ns "python chemfiles/parse_mmcif.py data/1HTQ.cif" "chemfiles/parse_mmcif_1HTQ_py.dat" "chemfiles-python,Parse mmCIF 1HTQ,"
+run_benchmark $nb "python chemfiles/parse_mmtf.py data/1CRN.mmtf" "chemfiles/parse_mmtf_1CRN_py.dat"  "chemfiles-python,Parse MMTF 1CRN,"
+run_benchmark $ns "python chemfiles/parse_mmtf.py data/1HTQ.mmtf" "chemfiles/parse_mmtf_1HTQ_py.dat"  "chemfiles-python,Parse MMTF 1HTQ,"
+run_benchmark $nb "python chemfiles/count.py"                     "chemfiles/count_py.dat"            "chemfiles-python,Count,"
+run_benchmark $nb "python chemfiles/distance.py"                  "chemfiles/distance_py.dat"         "chemfiles-python,Distance,"
+run_benchmark $nb "python chemfiles/ramachandran.py"              "chemfiles/ramachandran_py.dat"     "chemfiles-python,Ramachandran,"
+
+# chemfiles -- C++
+run_benchmark $nb "chemfiles/parse_pdb data/1CRN.pdb"   "chemfiles/parse_pdb_1CRN_cxx.dat"   "chemfiles-cxx,Parse PDB 1CRN,"
+# run_benchmark $ns "chemfiles/parse_pdb data/1HTQ.pdb"   "chemfiles/parse_pdb_1HTQ_cxx.dat"   "chemfiles-cxx,Parse PDB 1HTQ,"
+run_benchmark $nb "chemfiles/parse_mmcif data/1CRN.cif" "chemfiles/parse_mmcif_1CRN_cxx.dat" "chemfiles-cxx,Parse mmCIF 1CRN,"
+run_benchmark $ns "chemfiles/parse_mmcif data/1HTQ.cif" "chemfiles/parse_mmcif_1HTQ_cxx.dat" "chemfiles-cxx,Parse mmCIF 1HTQ,"
+run_benchmark $nb "chemfiles/parse_mmtf data/1CRN.mmtf" "chemfiles/parse_mmtf_1CRN_cxx.dat"  "chemfiles-cxx,Parse MMTF 1CRN,"
+run_benchmark $ns "chemfiles/parse_mmtf data/1HTQ.mmtf" "chemfiles/parse_mmtf_1HTQ_cxx.dat"  "chemfiles-cxx,Parse MMTF 1HTQ,"
+run_benchmark $nb "chemfiles/count"                     "chemfiles/count_cxx.dat"            "chemfiles-cxx,Count,"
+run_benchmark $nb "chemfiles/distance"                  "chemfiles/distance_cxx.dat"         "chemfiles-cxx,Distance,"
+run_benchmark $nb "chemfiles/ramachandran"              "chemfiles/ramachandran_cxx.dat"     "chemfiles-cxx,Ramachandran,"
+echo "chemfiles benchmarks done"
+
 # Plot results
 julia plot/plot.jl
 echo "Results plotted"


### PR DESCRIPTION
I've added both a C++ and a Python version to try to measure Python binding overhead. Le me know if I should also add a Julia version =)

You can install the Python version with pip or conda, the C++ version uses a pre-compiled library from conda (see `chemfiles/README.md`).

There are at least two limitation with these benchmarks: parsing 1HTQ uncovered a bug in chemfiles (https://github.com/chemfiles/chemfiles/issues/328), so I disabled parsing this file for now, until we release the next version of chemfiles. The second issue is that the chain name was only made available to selections recently (it is used in the "distance" benchmark)

If you want to run benchmarks with chemfiles' latest master (and both above bugs fixed), I can help you to get it on your machine. It should be a few git operations + compiling everything from source.